### PR TITLE
Made lists into numbers for max-lon tests to pass

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -163,9 +163,9 @@
 
 (module+ test
   (check-equal? (max-lon '(1)) 1)
-  (check-equal? (max-lon '(1 2)) '(2))
-  (check-equal? (max-lon '(2 1)) '(2))
-  (check-equal? (max-lon '(2 3 1)) '(3)))
+  (check-equal? (max-lon '(1 2)) 2)
+  (check-equal? (max-lon '(2 1)) 2)
+  (check-equal? (max-lon '(2 3 1)) 3))
 
 ;; [Listof Real] -> [Listof Real]
 ;; Sort list into ascending order


### PR DESCRIPTION
The function `max-lon` is of type `[Pairof Real [Listof Real]] -> Real`. However 3 of the tests look for a `Listof Real`. Pull request just removes the list quote and parenthesis around the numbers