### PR TITLE
Fix Polymorphic Sort Function Argument and Second test

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -209,12 +209,12 @@
 ;; ∀ (α) (α α -> Boolean) [Listof α] -> [Listof α]
 ;; Sort list in ascending order according to given comparison
 ;; ENSURE: result is stable
-(define (sort < xs) xs)
+(define (sort f xs) xs)
 
 (module+ test
   (check-equal? (sort < '(1 -2 3)) '(-2 1 3))
-  (check-equal? (sort string<? '("abc" "d" "efg")) '("d" "abc" "efg"))  
-  (check-equal? 
+  (check-equal? (sort string<? '("d" "abc" "efg")) '("abc" "d" "efg"))
+  (check-equal?
    (sort (λ (s1 s2)
            (< (string-length s1) (string-length s2)))
          '("efg" "d" "abc")) '("d" "efg" "abc")))

--- a/main.rkt
+++ b/main.rkt
@@ -215,7 +215,7 @@
   (check-equal? (sort < '(1 -2 3)) '(-2 1 3))
   (check-equal? (sort string<? '("d" "abc" "efg")) '("abc" "d" "efg"))
   (check-equal?
-   (sort (λ (s1 s2)
+   (sort (lambda (s1 s2)
            (< (string-length s1) (string-length s2)))
          '("efg" "d" "abc")) '("d" "efg" "abc")))
 

--- a/main.rkt
+++ b/main.rkt
@@ -209,13 +209,13 @@
 ;; ∀ (α) (α α -> Boolean) [Listof α] -> [Listof α]
 ;; Sort list in ascending order according to given comparison
 ;; ENSURE: result is stable
-(define (sort f xs) xs)
+(define (sort < xs) xs)
 
 (module+ test
   (check-equal? (sort < '(1 -2 3)) '(-2 1 3))
   (check-equal? (sort string<? '("d" "abc" "efg")) '("abc" "d" "efg"))
   (check-equal?
-   (sort (lambda (s1 s2)
+   (sort (λ (s1 s2)
            (< (string-length s1) (string-length s2)))
          '("efg" "d" "abc")) '("d" "efg" "abc")))
 


### PR DESCRIPTION
Two things in this PR

1. Function argument was a "<" I changed it to an f.
2. The Second test had the already sorted list being tested. They have been switched. 
This was confirmed using Racket's built in sort just to make sure.
3. Make λ into lambda